### PR TITLE
Add snapcraft yaml to make snap which fixes #13

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: emoj
+version: '0.3.0'
+summary: emoj
+description: |
+  Find relevant emoji from text on the command-line.
+
+grade: stable
+confinement: strict
+
+apps:
+  emoj:
+    command: bin/emoj
+    plugs: [network]
+
+parts:
+  emoj:
+    plugin: nodejs
+    source: .


### PR DESCRIPTION
Can be tested on an up to date Ubuntu 16.04 system:-

`sudo apt install snapcraft`

Then within this directory:-

`snapcraft`

Which will build the snap. Then the following to install it:-

`sudo snap install emoj_0.3.0_amd64.snap --force-dangerous`

(the `--force-dangerous` is because we're side-loading, rather than installing from a store)