### PR TITLE
Add ability to specify number of emojis and update the behavior if stdout is not a TTY

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,18 +1,24 @@
 #!/usr/bin/env node
 'use strict';
-const dns = require('dns');
-const readline = require('readline');
-const meow = require('meow');
-const logUpdate = require('log-update');
 const chalk = require('chalk');
 const debounce = require('lodash.debounce');
-const hasAnsi = require('has-ansi');
-const mem = require('mem');
+const dns = require('dns');
 const emoj = require('./');
+const hasAnsi = require('has-ansi');
+const logUpdate = require('log-update');
+const mem = require('mem');
+const meow = require('meow');
+const os = require('os');
+const process = require('process');
+const readline = require('readline');
 
-// limit it to 7 results so not to overwhelm the user
-// this also reduces the chance of showing unrelated emojis
-const fetch = mem(str => emoj(str).then(arr => arr.slice(0, 7).join('  ')));
+// limit it to 7 results so not to overwhelm the user.  this also reduces the
+// chance of showing unrelated emojis. If we're piping to another process, just
+// give 1. This makes `emoj | pbcopy` easier.
+
+let numEmojis = process.stdout.isTTY ? 7 : 1
+
+const fetch = mem(str => emoj(str).then(arr => arr.slice(0, numEmojis).join('  ')));
 
 const debouncer = debounce(cb => cb(), 200);
 
@@ -20,15 +26,28 @@ const cli = meow(`
 	Usage
 	  $ emoj [text]
 
+  Options
+    -n, --number Number of Emojis to return (maximum 10)
+
 	Example
 	  $ emoj 'i love unicorns'
 	  🦄  🎠  🐴  🐎  ❤  ✨  🌈
 
 	Run it without arguments to enter the live search
-`);
+`, {
+  alias: {
+    n: 'number'
+  }
+});
+
+if ('number' in cli.flags) {
+  numEmojis = cli.flags['n'] > 10 ? 10 : cli.flags['n']
+}
+
 
 if (cli.input.length > 0) {
-	fetch(cli.input[0]).then(console.log);
+  let term = process.stdout.isTTY ? os.EOL : '';
+	fetch(cli.input[0]).then((r) => process.stdout.write(r + term));
 	return;
 }
 

--- a/cli.js
+++ b/cli.js
@@ -1,22 +1,23 @@
 #!/usr/bin/env node
 'use strict';
-const chalk = require('chalk');
-const debounce = require('lodash.debounce');
+
 const dns = require('dns');
-const emoj = require('./');
-const hasAnsi = require('has-ansi');
-const logUpdate = require('log-update');
-const mem = require('mem');
-const meow = require('meow');
+const readline = require('readline');
 const os = require('os');
 const process = require('process');
-const readline = require('readline');
+const meow = require('meow');
+const logUpdate = require('log-update');
+const chalk = require('chalk');
+const debounce = require('lodash.debounce');
+const hasAnsi = require('has-ansi');
+const mem = require('mem');
+const emoj = require('./');
 
 // limit it to 7 results so not to overwhelm the user.  this also reduces the
 // chance of showing unrelated emojis. If we're piping to another process, just
 // give 1. This makes `emoj | pbcopy` easier.
 
-let numEmojis = process.stdout.isTTY ? 7 : 1
+let numEmojis = process.stdout.isTTY ? 7 : 1;
 
 const fetch = mem(str => emoj(str).then(arr => arr.slice(0, numEmojis).join('  ')));
 
@@ -35,19 +36,18 @@ const cli = meow(`
 
 	Run it without arguments to enter the live search
 `, {
-  alias: {
-    n: 'number'
-  }
+	alias: {
+		n: 'number'
+	}
 });
 
 if ('number' in cli.flags) {
-  numEmojis = cli.flags['n'] > 10 ? 10 : cli.flags['n']
+	numEmojis = cli.flags.number > 10 ? 10 : cli.flags.number;
 }
 
-
 if (cli.input.length > 0) {
-  let term = process.stdout.isTTY ? os.EOL : '';
-	fetch(cli.input[0]).then((r) => process.stdout.write(r + term));
+	let term = process.stdout.isTTY ? os.EOL : '';
+	fetch(cli.input[0]).then(r => process.stdout.write(r + term));
 	return;
 }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   ],
   "dependencies": {
     "chalk": "^1.1.3",
+    "copy-paste": "^1.3.0",
     "got": "^6.3.0",
     "has-ansi": "^2.0.0",
     "lodash.debounce": "^4.0.6",

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,9 @@ $ emoj --help
   Usage
     $ emoj [text]
 
+  Options
+    -n, --number Number of Emojis to return (maximum 10)
+
   Example
     $ emoj 'i love unicorns'
     🦄  🎠  🐴  🐎  ❤  ✨  🌈


### PR DESCRIPTION
These changes are designed to facilitate an easier method for copying
emojis to the clipboard with `pbcopy` (on OSX) or similar tools. If the
user is piping the output to another command, only give them a
single emoji unless they specify they'd like more. We cap the result at
10.
- Add variable to specify number of emojis to fetch
- Cause this to default to 0 when stdout is not a TTY
- Allow user to specify how many emojis they'd like with `-n` flag
- Do not break line when stdout is a not a TTY
