### PR TITLE
Improve copy option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -10,7 +10,6 @@ const hasAnsi = require('has-ansi');
 const mem = require('mem');
 const clipboardy = require('clipboardy');
 const inquirer = require('inquirer');
-
 const emoj = require('./');
 
 /**

--- a/cli.js
+++ b/cli.js
@@ -9,9 +9,9 @@ const debounce = require('lodash.debounce');
 const hasAnsi = require('has-ansi');
 const mem = require('mem');
 const clipboardy = require('clipboardy');
-const emoj = require('./');
-
 const inquirer = require('inquirer');
+
+const emoj = require('./');
 
 /**
  * clampIndex - Return index between min and max, one-indexed.
@@ -22,19 +22,18 @@ const inquirer = require('inquirer');
  * @return {number} Index between min and max.
  */
 function clampIndex(index, min, max) {
-  const copyIndex = parseInt(index);
+	const copyIndex = parseInt(index, 10);
 
-  if (isNaN(copyIndex) || copyIndex < min + 1) {
-    // return minimum if index is no number or below minimum
-    return min;
-  }
-  else if (copyIndex > max) {
-    // return maximum if index is above maximum
-    return max;
-  }
+	if (isNaN(copyIndex) || copyIndex < min + 1) {
+		// return minimum if index is no number or below minimum
+		return min;
+	} else if (copyIndex > max) {
+		// return maximum if index is above maximum
+		return max;
+	}
 
-  // return index one-indexed
-  return copyIndex - 1;
+	// return index one-indexed
+	return copyIndex - 1;
 }
 
 // Limit it to 7 results so not to overwhelm the user
@@ -65,58 +64,58 @@ const cli = meow(`
 	}
 });
 
-const shouldCopy = cli.flags.hasOwnProperty('copy');
+const shouldCopy = Object.prototype.hasOwnProperty.call(cli.flags, 'copy');
 
 // move `--copy` argument to input, if it's no index (NaN)
 if (shouldCopy && cli.input.length === 0 && isNaN(cli.flags.copy)) {
-  cli.input = [cli.flags.copy];
-  cli.flags = {};
+	cli.input = [cli.flags.copy];
+	cli.flags = {};
 }
 
 if (cli.input.length > 0) {
-  fetch(cli.input[0]).then(choices => {
-    if (shouldCopy) {
-      // if `--copy` is set, use the (optional) index to copy into
-      // clipboard
-      const index = clampIndex(cli.flags.copy, 0, choices.length - 1);
-      const selection = choices[index];
+	fetch(cli.input[0]).then(choices => {
+		if (shouldCopy) {
+			// if `--copy` is set, use the (optional) index to copy into
+			// clipboard
+			const index = clampIndex(cli.flags.copy, 0, choices.length - 1);
+			const selection = choices[index];
 
-      // copy selection to clipboard
-      clipboardy.writeSync(selection);
+			// copy selection to clipboard
+			clipboardy.writeSync(selection);
 
-      // highlight selection
-      const pre = chalk.bold.cyan('›');
-      const elements = choices.map((item, mapIndex) => {
-        if (mapIndex === index) {
-          return chalk.cyan(item);
-        }
+			// highlight selection
+			const pre = chalk.bold.cyan('›');
+			const elements = choices.map((item, mapIndex) => {
+				if (mapIndex === index) {
+					return chalk.cyan(item);
+				}
 
-        return item;
-      });
+				return item;
+			});
 
-      // return highlighted selection
-      console.log(`${pre} ${elements.join('  ')}`);
-    } else {
-      // if not explicitly set, inquire the index of the emoji to copy
-      // to clipboard
-      inquirer
-        .prompt([
-          {
-            type: 'list',
-            message: 'Select emoji from this list:',
-            name: 'selection',
-            choices: choices,
-          },
-        ])
-        .then(answers => {
-          // copy selection to clipboard
-          // (selection is automatically printed by `inquirer`)
-          clipboardy.writeSync(answers.selection);
-        });
-    }
-  });
+			// return highlighted selection
+			console.log(`${pre} ${elements.join('  ')}`);
+		} else {
+			// if not explicitly set, inquire the index of the emoji to copy
+			// to clipboard
+			inquirer
+				.prompt([
+					{
+						type: 'list',
+						message: 'Select emoji from this list:',
+						name: 'selection',
+						choices: choices
+					}
+				])
+				.then(answers => {
+					// copy selection to clipboard
+					// (selection is automatically printed by `inquirer`)
+					clipboardy.writeSync(answers.selection);
+				});
+		}
+	});
 
-  return;
+	return;
 }
 
 readline.emitKeypressEvents(process.stdin);

--- a/cli.js
+++ b/cli.js
@@ -85,6 +85,7 @@ if (cli.input.length > 0) {
 			// highlight selection
 			const pre = chalk.bold.cyan('›');
 			const elements = choices.map((item, mapIndex) => {
+				// highlight selection for non-color emoji terminals
 				if (mapIndex === index) {
 					return chalk.cyan(item);
 				}
@@ -93,7 +94,7 @@ if (cli.input.length > 0) {
 			});
 
 			// return highlighted selection
-			console.log(`${pre} ${elements.join('  ')}`);
+			console.log(`${pre} ${elements.join('  ')} : ${selection}`);
 		} else {
 			// if not explicitly set, inquire the index of the emoji to copy
 			// to clipboard

--- a/cli.js
+++ b/cli.js
@@ -11,6 +11,8 @@ const mem = require('mem');
 const clipboardy = require('clipboardy');
 const emoj = require('./');
 
+const inquirer = require('inquirer');
+
 /**
  * clampIndex - Return index between min and max, one-indexed.
  *
@@ -73,26 +75,45 @@ if (shouldCopy && cli.input.length === 0 && isNaN(cli.flags.copy)) {
 
 if (cli.input.length > 0) {
   fetch(cli.input[0]).then(choices => {
-    // if `--copy` is set, use the (optional) index to copy into
-    // clipboard
-    const index = clampIndex(cli.flags.copy, 0, choices.length - 1);
-    const selection = choices[index];
+    if (shouldCopy) {
+      // if `--copy` is set, use the (optional) index to copy into
+      // clipboard
+      const index = clampIndex(cli.flags.copy, 0, choices.length - 1);
+      const selection = choices[index];
 
-    // copy selection to clipboard
-    clipboardy.writeSync(selection);
+      // copy selection to clipboard
+      clipboardy.writeSync(selection);
 
-    // highlight selection
-    const pre = chalk.bold.cyan('›');
-    const elements = choices.map((item, mapIndex) => {
-      if (mapIndex === index) {
-        return chalk.cyan(item);
-      }
+      // highlight selection
+      const pre = chalk.bold.cyan('›');
+      const elements = choices.map((item, mapIndex) => {
+        if (mapIndex === index) {
+          return chalk.cyan(item);
+        }
 
-      return item;
-    });
+        return item;
+      });
 
-    // return highlighted selection
-    console.log(`${pre} ${elements.join('  ')}`);
+      // return highlighted selection
+      console.log(`${pre} ${elements.join('  ')}`);
+    } else {
+      // if not explicitly set, inquire the index of the emoji to copy
+      // to clipboard
+      inquirer
+        .prompt([
+          {
+            type: 'list',
+            message: 'Select emoji from this list:',
+            name: 'selection',
+            choices: choices,
+          },
+        ])
+        .then(answers => {
+          // copy selection to clipboard
+          // (selection is automatically printed by `inquirer`)
+          clipboardy.writeSync(answers.selection);
+        });
+    }
   });
 
   return;

--- a/cli.js
+++ b/cli.js
@@ -19,14 +19,15 @@ const debouncer = debounce(cb => cb(), 200);
 
 const cli = meow(`
 	Usage
-	  $ emoj [text]
+	  $ emoj [OPTIONS] [text]
 
 	Example
 	  $ emoj 'i love unicorns'
 	  🦄  🎠  🐴  🐎  ❤  ✨  🌈
 
 	Options
-	  --copy -c  Copy the first emoji to the clipboard
+	  --copy -c [choice]  Copy the emoji on index <choice> to the clipboard
+	                      <choice> defaults to 1.
 
 	Run it without arguments to enter the live search
 `, {

--- a/cli.js
+++ b/cli.js
@@ -57,7 +57,8 @@ function clampIndex(index, min, max) {
 
 // Limit it to 7 results so not to overwhelm the user
 // This also reduces the chance of showing unrelated emojis
-const fetch = mem(str => emoj(str).then(arr => arr.slice(0, 7)));
+const emojiLimit = 7;
+const fetch = mem(str => emoj(str).then(arr => arr.slice(0, emojiLimit)));
 
 const debouncer = debounce(cb => cb(), 200);
 
@@ -177,14 +178,16 @@ process.stdin.on('keypress', (ch, key) => {
 		emojiIndex = Math.max(0, emojiIndex - 1);
 	} else if (key.name === 'right') {
 		// increase selected index
-		emojiIndex++;
+		emojiIndex = Math.min(emojiIndex + 1, emojiLimit - 1);
 	} else {
 		query.push(ch);
 	}
 
 	const queryStr = query.join('');
+	let indicator = prevResult.length <= 0 ? '' : `${'   '.repeat(emojiIndex)}^`;
 
-	logUpdate(`${pre}${chalk.bold(queryStr)}\n${stringifyEmojis(prevResult)}\n`);
+	// display emojis and indicator
+	logUpdate(`${pre}${chalk.bold(queryStr)}\n${stringifyEmojis(prevResult)}\n${indicator}`);
 
 	if (query.length <= 1) {
 		prevResult = [];
@@ -199,10 +202,11 @@ process.stdin.on('keypress', (ch, key) => {
 			}
 
 			// check and update upper bounds of emoji index
-			emojiIndex = Math.min(emojiIndex, emojis.length - 1);
 			prevResult = emojis;
-			const indicator = '   '.repeat(emojiIndex);
-			logUpdate(`${pre}${chalk.bold(query.join(''))}\n${stringifyEmojis(prevResult)}\n${indicator}Ʌ`);
+			indicator = prevResult.length <= 0 ? '' : `${'   '.repeat(emojiIndex)}^`;
+
+			// update emojis and indicator for new emoji
+			logUpdate(`${pre}${chalk.bold(queryStr)}\n${stringifyEmojis(prevResult)}\n${indicator}`);
 		});
 	});
 });

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "clipboardy": "^0.1.1",
     "got": "^6.3.0",
     "has-ansi": "^2.0.0",
+    "inquirer": "^3.0.6",
     "lodash.debounce": "^4.0.6",
     "log-update": "^1.0.2",
     "mem": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "clipboardy": "^0.1.1",
     "got": "^6.3.0",
     "has-ansi": "^2.0.0",
-    "inquirer": "^3.0.6",
     "lodash.debounce": "^4.0.6",
     "log-update": "^1.0.2",
     "mem": "^1.1.0",


### PR DESCRIPTION
Hello. :slightly_smiling_face: 

This PR is a proposal to fix #2: Check, whether there is a `--copy` flag given and copy the required emoji to the clipboard. For this purpose a `choice` parameter can be used to specify the requested index, which defaults to `1`.

There are several checks in place:
- `emoj --copy unicorn` - If `--copy` is given, but no input, try to use `choice` as input.
- `emoj --copy -5 unicorn` - Clamp the selection between 0 and the returned lists `length`.
- `emoj --copy 100 unicorn` - Same as above.

Furthermore without the `--copy` flag but with a `name` parameter `emoji` now utilizes `inquirer` to display an interactive selection for the emoji to copy to the clipboard. I found this is a more usable approach to handle an ambiguous result.


NOTE: While writing this PR message I noticed there are tests in place, that fail. I will update the PR as soon as possible to fix them. You can check out the current solution in the meantime and give notes. :+1: 