### PR TITLE
Add support for changing emoji skin tone

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -13,7 +13,6 @@ const skinTone = require('skin-tone');
 const Conf = require('conf');
 const emoj = require('./');
 
-
 // Limit it to 7 results so not to overwhelm the user
 // This also reduces the chance of showing unrelated emojis
 const fetch = mem(str => emoj(str).then(arr => arr.slice(0, 7)));
@@ -51,12 +50,7 @@ const cli = meow(`
 });
 
 if (typeof cli.flags.skinTone === 'number') {
-	if (cli.flags.skinTone <= 5) {
-		config.set('skinNumber', cli.flags.skinTone);
-	} else {
-		console.log('Skin tone must be a number between 0 and 5.');
-		return;
-	}
+	config.set('skinNumber', Math.max(0, Math.min(5, cli.flags.skinTone)));
 }
 
 let skinNumber = config.get('skinNumber');

--- a/cli.js
+++ b/cli.js
@@ -29,7 +29,7 @@ const cli = meow(`
 
 	Options
 	  --copy -c  Copy the first emoji to the clipboard
-	  --skin-tone -s  Set the skin tone of the emojis
+	  --skin-tone -s  Set the skin tone of the emojis (0 to 5)
 
 	Run it without arguments to enter the live search
 	Use Up/Down keys during live search to change the skin tones
@@ -46,7 +46,12 @@ const cli = meow(`
 
 let skinNumber = 0;
 if (cli.flags.skinTone) {
-	skinNumber = cli.flags.skinTone;
+	if (cli.flags.skinTone >= 0 && cli.flags.skinTone <= 5) {
+		skinNumber = cli.flags.skinTone;
+	} else {
+		console.log('Skin tone must be a number between 0 and 5.');
+		return;
+	}
 }
 
 if (cli.input.length > 0) {

--- a/cli.js
+++ b/cli.js
@@ -10,6 +10,7 @@ const hasAnsi = require('has-ansi');
 const mem = require('mem');
 const clipboardy = require('clipboardy');
 const skinTone = require('skin-tone');
+const Conf = require('conf');
 const emoj = require('./');
 
 
@@ -18,6 +19,12 @@ const emoj = require('./');
 const fetch = mem(str => emoj(str).then(arr => arr.slice(0, 7)));
 
 const debouncer = debounce(cb => cb(), 200);
+
+const config = new Conf({
+	defaults: {
+		skinNumber: 0
+	}
+});
 
 const cli = meow(`
 	Usage
@@ -29,14 +36,13 @@ const cli = meow(`
 
 	Options
 	  --copy -c  Copy the first emoji to the clipboard
-	  --skin-tone -s  Set the skin tone of the emojis (0 to 5)
+	  --skin-tone -s  Set the default skin tone of the emoji (0 to 5)
 
 	Run it without arguments to enter the live search
 	Use Up/Down keys during live search to change the skin tones
 `, {
 	boolean: [
-		'copy',
-		'skinTone'
+		'copy'
 	],
 	alias: {
 		c: 'copy',
@@ -44,15 +50,16 @@ const cli = meow(`
 	}
 });
 
-let skinNumber = 0;
-if (cli.flags.skinTone) {
-	if (cli.flags.skinTone >= 0 && cli.flags.skinTone <= 5) {
-		skinNumber = cli.flags.skinTone;
+if (typeof cli.flags.skinTone === 'number') {
+	if (cli.flags.skinTone <= 5) {
+		config.set('skinNumber', cli.flags.skinTone);
 	} else {
 		console.log('Skin tone must be a number between 0 and 5.');
 		return;
 	}
 }
+
+let skinNumber = config.get('skinNumber');
 
 if (cli.input.length > 0) {
 	fetch(cli.input[0]).then(val => {

--- a/cli.js
+++ b/cli.js
@@ -9,8 +9,8 @@ const debounce = require('lodash.debounce');
 const hasAnsi = require('has-ansi');
 const mem = require('mem');
 const clipboardy = require('clipboardy');
-const emoj = require('./');
 const skinTone = require('skin-tone');
+const emoj = require('./');
 
 
 // Limit it to 7 results so not to overwhelm the user
@@ -45,13 +45,14 @@ const cli = meow(`
 });
 
 let skinNumber = 0;
-if(cli.flags.skinTone){
+if (cli.flags.skinTone) {
 	skinNumber = cli.flags.skinTone;
 }
 
 if (cli.input.length > 0) {
 	fetch(cli.input[0]).then(val => {
-		console.log(val.map( x => skinTone(x, skinNumber)).join('  '));
+		val = val.map(x => skinTone(x, skinNumber));
+		console.log(val.join('  '));
 		clipboardy.writeSync(val[0]);
 	});
 	return;
@@ -96,10 +97,9 @@ process.stdin.on('keypress', (ch, key) => {
 		query.length = 0;
 	} else if (key.name === 'up' && skinNumber < 5) {
 		skinNumber++;
-	} else if(key.name === 'down' && skinNumber > 0) {
+	} else if (key.name === 'down' && skinNumber > 0) {
 		skinNumber--;
-	}
-	else {
+	} else {
 		query.push(ch);
 	}
 

--- a/cli.js
+++ b/cli.js
@@ -29,21 +29,29 @@ const cli = meow(`
 
 	Options
 	  --copy -c  Copy the first emoji to the clipboard
+	  --skin-tone -s  Set the skin tone of the emojis
 
 	Run it without arguments to enter the live search
 	Use Up/Down keys during live search to change the skin tones
 `, {
 	boolean: [
-		'copy'
+		'copy',
+		'skinTone'
 	],
 	alias: {
-		c: 'copy'
+		c: 'copy',
+		s: 'skinTone'
 	}
 });
 
+let skinNumber = 0;
+if(cli.flags.skinTone){
+	skinNumber = cli.flags.skinTone;
+}
+
 if (cli.input.length > 0) {
 	fetch(cli.input[0]).then(val => {
-		console.log(val.join('  '));
+		console.log(val.map( x => skinTone(x, skinNumber)).join('  '));
 		clipboardy.writeSync(val[0]);
 	});
 	return;
@@ -55,7 +63,6 @@ process.stdin.setRawMode(true);
 const pre = `\n${chalk.bold.cyan('›')} `;
 const query = [];
 let prevResult = '';
-let skinNumber = 0;
 
 dns.lookup('emoji.getdango.com', err => {
 	if (err && err.code === 'ENOTFOUND') {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "clipboardy": "^0.1.1",
+    "conf": "^1.0.0",
     "got": "^6.3.0",
     "has-ansi": "^2.0.0",
     "lodash.debounce": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "lodash.debounce": "^4.0.6",
     "log-update": "^1.0.2",
     "mem": "^1.1.0",
-    "meow": "^3.7.0"
+    "meow": "^3.7.0",
+    "skin-tone": "^1.0.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ $ emoj --help
 
   Options
     --copy -c  Copy the first emoji to the clipboard
-    --skin-tone -s  Set the skin tone of the emojis
+    --skin-tone -s  Set the skin tone of the emojis (0 to 5)
 
   Run it without arguments to enter the live search
   Use Up/Down keys during live search to change the skin tones

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ $ emoj --help
 
   Options
     --copy -c  Copy the first emoji to the clipboard
-    --skin-tone -s  Set the skin tone of the emojis (0 to 5)
+    --skin-tone -s  Set the skin tone of the emoji (0 to 5)
 
   Run it without arguments to enter the live search
   Use Up/Down keys during live search to change the skin tones

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,7 @@ $ emoj --help
     --copy -c  Copy the first emoji to the clipboard
 
   Run it without arguments to enter the live search
+  Use Up/Down keys during live search to change the skin tones
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ $ emoj --help
 
   Options
     --copy -c  Copy the first emoji to the clipboard
+    --skin-tone -s  Set the skin tone of the emojis
 
   Run it without arguments to enter the live search
   Use Up/Down keys during live search to change the skin tones

--- a/readme.md
+++ b/readme.md
@@ -32,11 +32,11 @@ $ emoj --help
     🦄  🎠  🐴  🐎  ❤  ✨  🌈
 
   Options
-    --copy -c  Copy the first emoji to the clipboard
-    --skin-tone -s  Set the default skin tone of the emoji (0 to 5)
+    --copy -c   Copy the first emoji to the clipboard
+    --skin-tone -s  Set and persist the default emoji skin tone (0 to 5)
 
   Run it without arguments to enter the live search
-  Use Up/Down keys during live search to change the skin tones
+  Use the up/down keys during live search to change the skin tone
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ $ emoj --help
 
   Options
     --copy -c  Copy the first emoji to the clipboard
-    --skin-tone -s  Set the skin tone of the emoji (0 to 5)
+    --skin-tone -s  Set the default skin tone of the emoji (0 to 5)
 
   Run it without arguments to enter the live search
   Use Up/Down keys during live search to change the skin tones


### PR DESCRIPTION
Fixes #4 

It implements the Up/Down key presses to change the skin tone in interactive mode, and the `--skin-tone` flag which affects both modes.

Two considerations:
- **Persistence**: I understand the `--skin-tone` flag should make the setting persistent across different program runs. I think this can be achieved by writing this option to a file (which to me sounds a bit _overkill_, for saving only one numeric value), or by setting/accessing it through an Enviroment Variable.
However, I think the same effect could easily be achieved if a user just creates his own _alias_ for the program with the flag set to his preference. What do you think?

- **Tests**: I had added a very simple **ava** test for testing the new flag, but the output of toned-emojis is different in a Linux terminal - it shows 2 characters: the original emoji followed by a greyscale square, which differs from the expected output of a single toned emoji character -- even though the output is actually correct: the two characters combined form the intended toned emoji if you paste them together in a text-editor or browser. I suspect the test would pass in a Mac, but I am unable to do so, and because of the discrepancy I have decided to remove the test altogether.
Also, since the output always comes from the Dango neural network API, it is never guaranteed that an output remains the same given the same query in different instances, so this kind of test is inconsistent.