### PR TITLE
Use `emojilib` to enhance results

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,14 +12,14 @@ const getGetdangoEmojis = async input => {
 	return results.map(result => result.text);
 };
 
-// This value was picked experimentally
+// This value was picked experimentally, substring search returns a lot of noise for shorter search words
 const MIN_WORD_LENGTH_FOR_SUBSTRING_SEARCH = 4;
 
 const getEmojilibEmojis = input => {
 	const reSource = input.toLowerCase().split(/\s/g)
 		.map(v => v.replace(/\W/g, ''))
 		.filter(v => v.length > 0)
-		.map(v => v.length < MIN_WORD_LENGTH_FOR_SUBSTRING_SEARCH ? `^${v}$` : v) // Substring search returns a lot of noise for short search words
+		.map(v => v.length < MIN_WORD_LENGTH_FOR_SUBSTRING_SEARCH ? `^${v}$` : v)
 		.join('|');
 
 	if (reSource.length === 0) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 const got = require('got');
+const emojilib = require('emojilib');
 
-module.exports = async input => {
+const getGetdangoEmojis = async input => {
 	const {results} = await got('http://emoji.getdango.com/api/emoji', {
 		searchParams: {
 			q: input
@@ -9,4 +10,46 @@ module.exports = async input => {
 	}).json();
 
 	return results.map(result => result.text);
+};
+
+const getEmojilibEmojis = input => {
+	const reSource = input.toLowerCase().split(/\s/g)
+		.map(v => v.replace(/\W/g, ''))
+		.filter(v => v.length > 0)
+		.map(v => (v.length >= 4) ? v : '^' + v + '$')
+		.join('|');
+
+	if (reSource.length === 0) {
+		return [];
+	}
+
+	const re = new RegExp(reSource);
+	const emojis = [];
+
+	for (const [name, data] of Object.entries(emojilib.lib)) {
+		let matches = re.test(name);
+		for (const keyword of data.keywords) {
+			matches = matches || re.test(keyword);
+		}
+
+		if (matches) {
+			emojis.push(data.char);
+		}
+	}
+
+	return emojis;
+};
+
+module.exports = async input => {
+	const set = new Set();
+
+	for (const emoji of getEmojilibEmojis(input)) {
+		set.add(emoji);
+	}
+
+	for (const emoji of await getGetdangoEmojis(input)) {
+		set.add(emoji);
+	}
+
+	return [...set];
 };

--- a/index.js
+++ b/index.js
@@ -54,10 +54,7 @@ module.exports = async input => {
 		for (const emoji of await getGetdangoEmojis(input)) {
 			set.add(emoji);
 		}
-	} catch (error) {
-		if (set.size === 0) {
-			throw error;
-		}
+	} catch (_) {
 	}
 
 	return [...set];

--- a/index.js
+++ b/index.js
@@ -47,8 +47,14 @@ module.exports = async input => {
 		set.add(emoji);
 	}
 
-	for (const emoji of await getGetdangoEmojis(input)) {
-		set.add(emoji);
+	try {
+		for (const emoji of await getGetdangoEmojis(input)) {
+			set.add(emoji);
+		}
+	} catch (error) {
+		if (set.size === 0) {
+			throw error;
+		}
 	}
 
 	return [...set];

--- a/index.js
+++ b/index.js
@@ -12,11 +12,14 @@ const getGetdangoEmojis = async input => {
 	return results.map(result => result.text);
 };
 
+// This value was picked experimentally
+const MIN_WORD_LENGTH_FOR_SUBSTRING_SEARCH = 4;
+
 const getEmojilibEmojis = input => {
 	const reSource = input.toLowerCase().split(/\s/g)
 		.map(v => v.replace(/\W/g, ''))
 		.filter(v => v.length > 0)
-		.map(v => (v.length >= 4) ? v : '^' + v + '$')
+		.map(v => v.length < MIN_WORD_LENGTH_FOR_SUBSTRING_SEARCH ? `^${v}$` : v) // Substring search returns a lot of noise for short search words
 		.join('|');
 
 	if (reSource.length === 0) {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"auto-bind": "^4.0.0",
 		"clipboardy": "^2.2.0",
 		"conf": "^6.2.1",
+		"emojilib": "^2.4.0",
 		"got": "^10.6.0",
 		"import-jsx": "^3.1.0",
 		"ink": "^2.7.1",

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 <img src="screenshot.gif" width="660">
 
-Uses the API from this great article on [Emoji & Deep Learning](http://getdango.com/emoji-and-deep-learning.html).<br>
+Uses the API from this great article on [Emoji & Deep Learning](http://getdango.com/emoji-and-deep-learning.html) and local emoji database.<br>
 Check out the [Dango app](https://getdango.com) if you want something like this on your phone.
 
 ## Install

--- a/test.js
+++ b/test.js
@@ -5,3 +5,8 @@ test('main', async t => {
 	const [unicornEmoji] = await emoj('unicorn');
 	t.is(unicornEmoji, '🦄');
 });
+
+test('local db emojis', async t => {
+	t.true((await emoj('crossed')).includes('🤞'));
+	t.true((await emoj('drool')).includes('🤤'));
+});

--- a/ui.js
+++ b/ui.js
@@ -1,5 +1,4 @@
 'use strict';
-const dns = require('dns');
 const React = require('react');
 const {Box, Color, Text, AppContext, StdinContext} = require('ink');
 const TextInput = require('ink-text-input').default;
@@ -19,9 +18,8 @@ const fetch = mem(async string => {
 const debouncer = debounce(cb => cb(), 200);
 
 const STAGE_CHECKING = 0;
-const STAGE_OFFLINE = 1;
-const STAGE_SEARCH = 2;
-const STAGE_COPIED = 3;
+const STAGE_SEARCH = 1;
+const STAGE_COPIED = 2;
 
 // TODO: Move these to https://github.com/sindresorhus/ansi-escapes
 const ARROW_UP = '\u001B[A';
@@ -31,20 +29,6 @@ const ARROW_RIGHT = '\u001B[C';
 const ESC = '\u001B';
 const CTRL_C = '\u0003';
 const RETURN = '\r';
-
-const OfflineMessage = () => (
-	<Box>
-		<Text bold>
-			<Color red>
-				›
-			</Color>
-		</Text>
-
-		<Color dim>
-			{' Please check your internet connection'}
-		</Color>
-	</Box>
-);
 
 const QueryInput = ({query, placeholder, onChange}) => (
 	<Box>
@@ -126,7 +110,6 @@ class Emoj extends React.PureComponent {
 
 		return (
 			<Box>
-				{stage === STAGE_OFFLINE && <OfflineMessage/>}
 				{stage === STAGE_COPIED && <CopiedMessage emoji={selectedEmoji}/>}
 				{stage === STAGE_SEARCH && (
 					<Search
@@ -142,17 +125,8 @@ class Emoj extends React.PureComponent {
 	}
 
 	componentDidMount() {
-		dns.lookup('emoji.getdango.com', error => {
-			const stage = error && error.code === 'ENOTFOUND' ? STAGE_OFFLINE : STAGE_SEARCH;
-
-			this.setState({stage}, () => {
-				if (stage === STAGE_OFFLINE) {
-					this.props.onError();
-					return;
-				}
-
-				this.props.stdin.on('data', this.handleInput);
-			});
+		this.setState({stage: STAGE_SEARCH}, () => {
+			this.props.stdin.on('data', this.handleInput);
 		});
 	}
 


### PR DESCRIPTION
Adds `emojilib` results to what we get from getdango.

Filtering of `emojilib` is done with simple heuristic(ignore some characters, do exact matches on long searches, substring matches on short searches).

Also, allowed using only `emojilib` if getdango API is not available for some reason.

Fixes #30 
Closes #40