### PR TITLE
Prevent setState after unmount

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -83,6 +83,8 @@ class Emoj extends React.PureComponent {
 		super(props);
 		autoBindReact(this);
 
+		this.exiting = false;
+
 		this.state = {
 			stage: STAGE_CHECKING,
 			query: '',
@@ -140,6 +142,7 @@ class Emoj extends React.PureComponent {
 		let {skinNumber, selectedIndex, emojis, query} = this.state;
 
 		if (input === ESC || input === CTRL_C) {
+			this.exiting = true;
 			onExit();
 			return;
 		}
@@ -221,7 +224,7 @@ class Emoj extends React.PureComponent {
 		debouncer(async () => {
 			const emojis = await fetch(query);
 
-			if (this.state.query.length > 1) {
+			if (this.state.query.length > 1 && !this.exiting) {
 				this.setState({emojis});
 			}
 		});


### PR DESCRIPTION
Hello 👋 

When running `emoj` with no arguments, then typing any string of characters, followed by pressing <kbd>esc</kbd>, I noticed that I was getting
```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
    in Emoj (created by Context.Consumer)
    in Unknown
    in App
```

I narrowed this down to `fetchEmojis` attempting to set the state after the component had unmounted.

This PR prevents that warning by blocking `fetchEmojis` from attempting to set state after a user has input `ESC`.

I'm unfamiliar with using React components in CLI applications, so I apologize if these changes do not follow best practices.