### PR TITLE
Adds flag to set the limit on the number of emojis to be displayed

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -47,8 +47,7 @@ const cli = meow(`
 const config = new Conf({
 	projectName: 'emoj',
 	defaults: {
-		skinNumber: 0,
-		limit: 7
+		skinNumber: 0
 	}
 });
 
@@ -56,12 +55,8 @@ if (cli.flags.skinTone !== undefined) {
 	config.set('skinNumber', Math.max(0, Math.min(5, cli.flags.skinTone || 0)));
 }
 
-if (cli.flags.limit !== undefined) {
-	config.set('limit', Math.max(1, Math.min(100, cli.flags.limit || 0)));
-}
-
 const skinNumber = config.get('skinNumber');
-const limit = config.get('limit');
+const limit = Math.max(1, cli.flags.limit || 7);
 
 const main = async () => {
 	let app; // eslint-disable-line prefer-const

--- a/cli.js
+++ b/cli.js
@@ -22,6 +22,7 @@ const cli = meow(`
 	Options
 	  --copy -c       Copy the first emoji to the clipboard
 	  --skin-tone -s  Set and persist the default emoji skin tone (0 to 5)
+	  --limit -l      Maximum number of emojis to display (default: 7)
 
 	Run it without arguments to enter the live search
 	Use the up/down keys during live search to change the skin tone
@@ -35,6 +36,10 @@ const cli = meow(`
 		skinTone: {
 			type: 'number',
 			alias: 's'
+		},
+		limit: {
+			type: 'number',
+			alias: 'l'
 		}
 	}
 });
@@ -42,7 +47,8 @@ const cli = meow(`
 const config = new Conf({
 	projectName: 'emoj',
 	defaults: {
-		skinNumber: 0
+		skinNumber: 0,
+		limit: 7
 	}
 });
 
@@ -50,7 +56,12 @@ if (cli.flags.skinTone !== undefined) {
 	config.set('skinNumber', Math.max(0, Math.min(5, cli.flags.skinTone || 0)));
 }
 
+if (cli.flags.limit !== undefined) {
+	config.set('limit', Math.max(1, Math.min(100, cli.flags.limit || 0)));
+}
+
 const skinNumber = config.get('skinNumber');
+const limit = config.get('limit');
 
 const main = async () => {
 	let app; // eslint-disable-line prefer-const
@@ -61,7 +72,7 @@ const main = async () => {
 	};
 
 	// Uses `React.createElement` instead of JSX to avoid transpiling this file.
-	app = render(React.createElement(ui, {skinNumber, onSelectEmoji}));
+	app = render(React.createElement(ui, {skinNumber, limit, onSelectEmoji}));
 
 	await app.waitUntilExit();
 };
@@ -69,7 +80,7 @@ const main = async () => {
 if (cli.input.length > 0) {
 	(async () => {
 		const emojis = (await emoj(cli.input[0]))
-			.slice(0, 7)
+			.slice(0, limit)
 			.map(emoji => skinTone(emoji, skinNumber));
 
 		console.log(emojis.join('  '));

--- a/ui.js
+++ b/ui.js
@@ -26,9 +26,9 @@ const useDebouncedValue = (value, delay) => {
 
 // Limit it to 7 results so not to overwhelm the user
 // This also reduces the chance of showing unrelated emojis
-const fetch = mem(async string => {
+const fetch = mem(async (string, upperBound) => {
 	const array = await emoj(string);
-	return array.slice(0, 7);
+	return array.slice(0, upperBound);
 });
 
 const STAGE_CHECKING = 0;
@@ -77,7 +77,7 @@ const Search = ({query, emojis, skinNumber, selectedIndex, onChangeQuery}) => {
 	);
 };
 
-const Emoj = ({skinNumber: initialSkinNumber, onSelectEmoji}) => {
+const Emoj = ({skinNumber: initialSkinNumber, limit, onSelectEmoji}) => {
 	const {exit} = useApp();
 	const [stage, setStage] = useState(STAGE_CHECKING);
 	const [query, setQuery] = useState('');
@@ -112,7 +112,7 @@ const Emoj = ({skinNumber: initialSkinNumber, onSelectEmoji}) => {
 		let isCanceled = false;
 
 		const run = async () => {
-			const emojis = await fetch(debouncedQuery);
+			const emojis = await fetch(debouncedQuery, limit);
 
 			// Don't update state when this effect was canceled to avoid
 			// results that don't match the search query


### PR DESCRIPTION
Fixes #51 

**Before**

Only 7 emojis were displayed even though some inputs can have more than 7 emojis.

**After**

With the flag `--limit` or `-l` the user can set the limit on the number of emojis they want to be displayed.

![image](https://user-images.githubusercontent.com/51032928/184590359-6be5b25d-80d3-4da5-89c4-28eb842eecf5.png)

![image](https://user-images.githubusercontent.com/51032928/184590410-40185acc-d5ca-4f48-8abc-a71aa9203fd4.png)
